### PR TITLE
fix: temporary fix pairing method

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,6 @@
       "number": 6283175395970,
       "code": "MOONXBOT",
       "browser": ["Ubuntu", "Firefox", "20.0.00"],
-      "verion": [2, 3000, 1029030078]
+      "version": [2, 3000, 1029030078]
    }
  }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 const { Connection, Database, Session, Function: Func, Config: env } = require('@znan/wabot')
 require('./lib/system/config'), require('./lib/system/function'), require('./lib/system/scraper')
 const fs = require('fs')
+const config = require('./config.json')
 
 const connect = async () => {
    const url = process?.env?.DATABASE_URL
@@ -15,11 +16,7 @@ const connect = async () => {
       online: true,
       presence: true,
       bypass_ephemeral: true,
-      pairing: {
-         state: env.pairing.state,
-         number: env.pairing.number,
-         code: env.pairing.number
-      },
+      pairing: config.pairing,
    }, {
       browser: env.pairing.browser,
       version: env.pairing.version,


### PR DESCRIPTION
## Temporary Fix: Pairing Configuration Not Loaded

### Summary
This PR introduces a temporary fix for an issue where the pairing configuration is not loaded correctly at runtime.

The issue is suspected to originate from `@znan/wabot`, where the `pairing` configuration defined in `config.json` is not properly exported or consumed.

---

### Changes
- Explicitly import `config.json` and pass `config.pairing` directly to the `Connection` constructor.
- Ensure the pairing configuration is correctly applied at runtime.
- Fix a typo in the configuration key from `verion` to `version`.

---

### Notes
- This is a temporary workaround.
- The upstream dependency cannot be modified as it is obfuscated.
- The workaround should be removed once the configuration export issue is resolved upstream.
