### PR TITLE
fix: set welcome/bye variable inconsistency and placeholder docs

### DIFF
--- a/plugins/admin/settext.js
+++ b/plugins/admin/settext.js
@@ -1,45 +1,38 @@
 module.exports = {
-   help: ['setwelcome', 'setbye'],
-   use: 'text',
-   tags: 'admin',
-   run: async (m, {
-      conn,
-      usedPrefix,
-      command,
-      text,
-      groupSet,
-      Func
-   }) => {
-      if (command == 'setwelcome') {
-         if (!text) return conn.reply(m.chat, formatWel(usedPrefix, command), m)
-         groupSet.sWelcome = text
-         await conn.reply(m.chat, Func.texted('bold', `🚩 Successfully set.`), m)
-      } else if (/set(out|left)/i.test(command)) {
-         if (!text) return conn.reply(m.chat, formatLef(usedPrefix, command), m)
-         groupSet.sBye = text
-         await conn.reply(m.chat, Func.texted('bold', `🚩 Successfully set.`), m)
-      }
-   },
-   group: true,
-   admin: true,
-   error: false
-}
+  help: ["setwelcome", "setbye"],
+  use: "text",
+  tags: "admin",
+  run: async (m, { conn, usedPrefix, command, text, groupSet, Func }) => {
+    if (command == "setwelcome") {
+      if (!text) return conn.reply(m.chat, formatWel(usedPrefix, command), m);
+      groupSet.text_welcome = text;
+      await conn.reply(m.chat, Func.texted("bold", `🚩 Successfully set.`), m);
+    } else if (/set(out|left)/i.test(command)) {
+      if (!text) return conn.reply(m.chat, formatLef(usedPrefix, command), m);
+      groupSet.text_left = text;
+      await conn.reply(m.chat, Func.texted("bold", `🚩 Successfully set.`), m);
+    }
+  },
+  group: true,
+  admin: true,
+  error: false,
+};
 
 const formatWel = (prefix, command) => {
-   return `Sorry, can't return without text, and this explanation and how to use :
+  return `Sorry, can't return without text, and this explanation and how to use :
 
-*1.* @tag : for mention new member on welcome message.
+*1.* @user : for mention new member on welcome message.
 *2.* @subject : for getting group name.
 *3.* @desc : for getting group description.
 
-• *Example* : ${prefix + command} Hi +tag, welcome to +grup group, we hope you enjoyed with us.`
-}
+• *Example* : ${prefix + command} Hi @user, welcome to @subject group, we hope you enjoyed with us.`;
+};
 
 const formatLef = (prefix, command) => {
-   return `Sorry, can't return without text, and this explanation and how to use :
+  return `Sorry, can't return without text, and this explanation and how to use :
 
-*1.* @tag : for mention new member on left message.
+*1.* @user : for mention new member on left message.
 *2.* @subject : for getting group name.
 
-• *Example* : ${prefix + command} Good by +tag`
-}
+• *Example* : ${prefix + command} Good by @user`;
+};


### PR DESCRIPTION
## Changes Made

- **Variable Standardization**: Updated `settext.js` to use consistent variable names (`sWelcome` → `text_welcome`, `sBye` → `text_left`) to match the keys used in `listeners.js` and `models.js`.
- **Documentation Fix**: Corrected placeholder examples in help messages from `@tag`/`+tag` to `@user` for accurate usage guidance. This aligns with the replacement logic in `listeners.js`:

  ```javascript
  const txt = (groupSet && groupSet.text_welcome ? groupSet.text_welcome : text)
    .replace("@user", `@${x.member.split`@`[0]}`)
    .replace("@subject", x.subject || "")
    .replace("@desc", x.groupMetadata.desc || "");
  ```

## Issue Resolved

- Custom welcome/bye messages now work properly (previously, set text was ignored due to mismatched variable names).
- Users can now use placeholders like `@user`, `@subject`, `@desc` without confusion.